### PR TITLE
Re-organize DatTCP's API methods for more control

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Making 10000 request(s):
 ....................................................................................................
-Total Time:   6441.3947ms
-Average Time:    0.6441ms
-Min Time:        0.4880ms
-Max Time:       47.0080ms
+Total Time:   6151.6778ms
+Average Time:    0.6151ms
+Min Time:        0.4630ms
+Max Time:       79.3111ms
 
 Done running benchmark report

--- a/bench/runner.rb
+++ b/bench/runner.rb
@@ -103,15 +103,14 @@ module Bench
       super(options)
     end
 
-    def start_server
+    def run_server
       require 'bench/server'
-      args = HOST_AND_PORT.dup.push({ :debug => true })
-      server = Bench::Server.new(*args)
+      host_and_port = HOST_AND_PORT.dup
+      server = Bench::Server.new({ :debug => !!ENV['DEBUG'] })
       [ "QUIT", "INT", "TERM" ].each do |name|
         Signal.trap(name){ server.stop }
       end
-      server.start
-      server.join_thread
+      server.run(*host_and_port).join
       self.write_report(server)
     end
 

--- a/bench/server_report.txt
+++ b/bench/server_report.txt
@@ -1,6 +1,6 @@
 Server statistics
-  Total Time:     0.5127ms
+  Total Time:     0.7565ms
   Average Time:   0.0000ms
   Min Time:       0.0000ms
-  Max Time:       0.0009ms
+  Max Time:       0.0003ms
 

--- a/bench/tasks.rb
+++ b/bench/tasks.rb
@@ -6,7 +6,7 @@ namespace :bench do
 
   desc "Start the Benchmark echo server"
   task :server => :load do
-    Bench::ServerRunner.new.start_server
+    Bench::ServerRunner.new.run_server
   end
 
   desc "Run a Benchmark report against the Benchmark server"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,7 @@ require 'socket'
 require 'dat-tcp'
 
 require 'test/support/echo_server'
+require 'test/support/test_server'
 require 'test/support/fake_socket'
 require 'test/support/spy_logger'
 

--- a/test/support/echo_server.rb
+++ b/test/support/echo_server.rb
@@ -2,18 +2,16 @@ class EchoServer
   include DatTCP::Server
 
   def serve(socket)
-    message = socket.gets("\n")
-    socket.puts(message)
+    socket.write(socket.read)
   end
 
   module Helpers
 
-    def start_server(server)
+    def start_server(server, *args)
       begin
         pid = fork do
           trap("TERM"){ server.stop }
-          server.start
-          server.join_thread
+          server.run(*args).join
         end
         sleep 0.3 # Give time for the socket to start listening.
         yield

--- a/test/support/test_server.rb
+++ b/test/support/test_server.rb
@@ -1,0 +1,27 @@
+class TestServer
+  include DatTCP::Server
+
+  attr_reader :on_listen_called, :on_run_called, :on_pause_called,
+    :on_stop_called, :on_halt_called
+
+  def on_listen
+    @on_listen_called = true
+  end
+
+  def on_run
+    @on_run_called = true
+  end
+
+  def on_pause
+    @on_pause_called = true
+  end
+
+  def on_stop
+    @on_stop_called = true
+  end
+
+  def on_halt
+    @on_halt_called = true
+  end
+
+end

--- a/test/unit/dat-tcp_test.rb
+++ b/test/unit/dat-tcp_test.rb
@@ -5,74 +5,166 @@ module DatTCP
   class BaseTest < Assert::Context
     desc "DatTCP"
     setup do
-      @server_class = Class.new do
-        include DatTCP::Server
-      end
-      @server = @server_class.new('localhost', 8000, {
-        :ready_timeout => 0
-      })
+      @server = TestServer.new({ :ready_timeout => 0 })
     end
     subject{ @server }
 
-    should have_instance_methods :host, :port, :workers, :logger, :tcp_server, :thread,
-      :start, :stop, :join_thread, :running?, :serve, :name, :ready_timeout
+    should have_instance_methods :logger
+    should have_instance_methods :listen, :run, :pause, :stop, :halt, :stop_listening
+    should have_instance_methods :listening?, :running?
+    should have_instance_methods :on_listen, :on_run, :on_pause, :on_stop, :on_halt
+    should have_instance_methods :serve
 
-    should "return an instance of DatTCP::Workers with #workers" do
-      assert_instance_of DatTCP::Workers, subject.workers
-    end
     should "return an instance of DatTCP::Logger::Null with #logger" do
       assert_instance_of DatTCP::Logger::Null, subject.logger
     end
-    should "return nil with #tcp_server and #thread" do
-      assert_nil subject.tcp_server
-      assert_nil subject.thread
-    end
-    should "return false with #running?" do
+
+    should "not be listening or running" do
+      assert_equal false, subject.listening?
       assert_equal false, subject.running?
     end
+
   end
 
-  class StartedTest < BaseTest
-    desc "started"
+  class ListenTest < BaseTest
+    desc "listen"
     setup do
-      @server.start
+      @server.listen('localhost', 45678)
+    end
+    teardown do
+      @server.stop_listening
+    end
+
+    should "be listening but not running" do
+      assert_equal true,  subject.listening?
+      assert_equal false, subject.running?
+    end
+
+    should "have created an instance of a TCP Server and started listening" do
+      assert_nothing_raised do
+        socket = TCPSocket.new('localhost', 45678)
+        socket.close
+      end
+    end
+
+    should "have called on_listen but no other hooks" do
+      assert_equal true, subject.on_listen_called
+      assert_nil subject.on_run_called
+      assert_nil subject.on_pause_called
+      assert_nil subject.on_stop_called
+      assert_nil subject.on_halt_called
+    end
+
+  end
+
+  class RunTest < BaseTest
+    desc "run"
+    setup do
+      @thread = @server.run('localhost', 45678)
     end
     teardown do
       @server.stop
     end
 
-    should "return true with #running?" do
+    should "return a thread for running the server" do
+      assert_instance_of Thread, @thread
+      assert @thread.alive?
+    end
+
+    should "be listening and running?" do
+      assert_equal true, subject.listening?
       assert_equal true, subject.running?
     end
-    should "have created an instance of a TCP Server" do
-      assert_instance_of TCPServer, subject.tcp_server
-      assert_nothing_raised do
-        socket = TCPSocket.new(subject.host, subject.port)
-        socket.close
-      end
+
+    should "have called on_listen and on_run but no other hooks" do
+      assert_equal true, subject.on_listen_called
+      assert_equal true, subject.on_run_called
+      assert_nil subject.on_pause_called
+      assert_nil subject.on_stop_called
+      assert_nil subject.on_halt_called
     end
-    should "have started a thread for running the TCP Server" do
-      assert_instance_of Thread, subject.thread
-      assert subject.thread.alive?
-    end
+
   end
 
-  class StoppedTest < StartedTest
-    desc "and then stopped"
+  class PauseTest < BaseTest
+    desc "pause"
     setup do
+      @thread = @server.run('localhost', 45678)
+      @server.pause
+    end
+    teardown do
+      @server.stop_listening
+    end
+
+    should "stop the thread" do
+      assert !@thread.alive?
+    end
+
+    should "be listening but not running" do
+      assert_equal true,  subject.listening?
+      assert_equal false, subject.running?
+    end
+
+    should "have called on_listen, on_run and on_pause but no other hooks" do
+      assert_equal true, subject.on_listen_called
+      assert_equal true, subject.on_run_called
+      assert_equal true, subject.on_pause_called
+      assert_nil subject.on_stop_called
+      assert_nil subject.on_halt_called
+    end
+
+  end
+
+  class StopTest < BaseTest
+    desc "stop"
+    setup do
+      @thread = @server.run('localhost', 45678)
       @server.stop
     end
 
-    should "return false with #running?" do
+    should "stop the thread" do
+      assert !@thread.alive?
+    end
+
+    should "not be listening or running" do
+      assert_equal false, subject.listening?
       assert_equal false, subject.running?
     end
-    should "have stopped the tcp server" do
-      assert_instance_of TCPServer, subject.tcp_server
-      assert subject.tcp_server.closed?
+
+    should "have called on_listen, on_run and on_pause but no other hooks" do
+      assert_equal true, subject.on_listen_called
+      assert_equal true, subject.on_run_called
+      assert_nil subject.on_pause_called
+      assert_equal true, subject.on_stop_called
+      assert_nil subject.on_halt_called
     end
-    should "have unset the thread" do
-      assert_nil subject.thread
+
+  end
+
+  class HaltTest < BaseTest
+    desc "halt"
+    setup do
+      @thread = @server.run('localhost', 45678)
+      @server.halt
     end
+
+    should "stop the thread" do
+      assert !@thread.alive?
+    end
+
+    should "not be listening or running" do
+      assert_equal false, subject.listening?
+      assert_equal false, subject.running?
+    end
+
+    should "have called on_listen, on_run and on_pause but no other hooks" do
+      assert_equal true, subject.on_listen_called
+      assert_equal true, subject.on_run_called
+      assert_nil subject.on_pause_called
+      assert_nil subject.on_stop_called
+      assert_equal true, subject.on_halt_called
+    end
+
   end
 
 end

--- a/test/unit/worker_pool_test.rb
+++ b/test/unit/worker_pool_test.rb
@@ -2,12 +2,12 @@ require 'assert'
 
 require 'benchmark'
 
-class DatTCP::Workers
+class DatTCP::WorkerPool
 
   class BaseTest < Assert::Context
-    desc "DatTCP::Workers"
+    desc "DatTCP::WorkerPool"
     setup do
-      @workers = DatTCP::Workers.new(1)
+      @workers = DatTCP::WorkerPool.new(1)
     end
     subject{ @workers }
 
@@ -18,7 +18,8 @@ class DatTCP::Workers
     desc "wait_for_available"
     setup do
       @sleep_time = sleep_time = 0.01
-      @workers.process(FakeSocket.new){|client| sleep(sleep_time) }
+      @workers = DatTCP::WorkerPool.new(1){|client| sleep(sleep_time) }
+      @workers.process(FakeSocket.new)
       @benchmark = Benchmark.measure{ @workers.wait_for_available }
     end
 
@@ -32,7 +33,8 @@ class DatTCP::Workers
     desc "process"
     setup do
       @client = FakeSocket.new
-      @workers.process(@client){|socket| socket.print('poop') }
+      @workers = DatTCP::WorkerPool.new(1){|socket| socket.print('poop') }
+      @workers.process(@client)
     end
 
     should "add a thread to the workers list" do
@@ -49,7 +51,8 @@ class DatTCP::Workers
     desc "finish"
     setup do
       @sleep_time = sleep_time = 0.01
-      @workers.process(FakeSocket.new){|client| sleep(sleep_time) }
+      @workers = DatTCP::WorkerPool.new(1){|client| sleep(sleep_time) }
+      @workers.process(FakeSocket.new)
       @benchmark = Benchmark.measure{ @workers.finish }
     end
 


### PR DESCRIPTION
This modifies DatTCP's API methods to allow more control of the
server.
- Added `pause` for stopping the server's work loop but still
  leaving the TCP connection open (so requests can queue up).
- Added `halt` for a non-graceful stopping of the server.
- Renamed `start` to `run` to line up with the `running?` state.
- `run` returns the thread it creates. This can then be joined,
  so the method `join_thread` is no longer needed. I prefered
  how this reads and it's one less method to support.
- Broke up the pieces of 'shutting down the server'. This is to
  support the different ways of shutting down (`pause`, `stop` and
  `halt`).
- Modified `Workers` to take a serve proc when it's created instead
  of everytime we accept a connection. I felt this was cleaner and
  slightly more efficient not having to create a new proc for every
  connection.

@kellyredding - The `pause` method is the meat of what is needed to support hot restarts. The rest of it is mostly things I saw in puma that I liked. I'm going to try to steal a few more ideas from puma's thread pool and apply them to the workers and see if there's any improvements, but that will appear in another PR.
