### PR TITLE
Stop spinning threads up for every connection

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Making 10000 request(s):
 ....................................................................................................
-Total Time:   2980.3067ms
-Average Time:    0.2980ms
-Min Time:        0.2410ms
-Max Time:       73.9350ms
+Total Time:   3201.8553ms
+Average Time:    0.3201ms
+Min Time:        0.2379ms
+Max Time:       72.5080ms
 
 Done running benchmark report

--- a/bench/runner.rb
+++ b/bench/runner.rb
@@ -106,7 +106,7 @@ module Bench
     def run_server
       require 'bench/server'
       host_and_port = HOST_AND_PORT.dup
-      server = Bench::Server.new({ :debug => !!ENV['BENCH_DEBUG'] })
+      server = Bench::Server.new({ :debug => !!ENV['DEBUG'] })
       [ "QUIT", "INT", "TERM" ].each do |name|
         Signal.trap(name){ server.stop }
       end

--- a/bench/server_report.txt
+++ b/bench/server_report.txt
@@ -1,6 +1,6 @@
 Server statistics
-  Total Time:     0.7584ms
+  Total Time:     0.8011ms
   Average Time:   0.0000ms
   Min Time:       0.0000ms
-  Max Time:       0.0735ms
+  Max Time:       0.0753ms
 

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -143,7 +143,8 @@ module DatTCP
 
     def work_loop
       self.logger.info "Starting work loop..."
-      setup_run
+      pool_args = [ @min_workers, @max_workers, @debug ]
+      @worker_pool = DatTCP::WorkerPool.new(*pool_args){|socket| serve(socket) }
       while @state.run?
         @worker_pool.enqueue_connection self.accept_connection
       end
@@ -157,13 +158,6 @@ module DatTCP
       close_connection if !@state.pause?
       clear_thread
       self.logger.info "Stopped work loop"
-    end
-
-    def setup_run
-      min, max = @min_workers, @max_workers
-      @worker_pool = DatTCP::WorkerPool.new(min, max, @debug) do |socket|
-        self.serve(socket)
-      end
     end
 
     # An accept-loop waiting for new connections. Will wait for a connection

--- a/test/system/echo_server_test.rb
+++ b/test/system/echo_server_test.rb
@@ -9,7 +9,7 @@ class EchoServerTest < Assert::Context
 
   desc "defining a custom Echo Server"
   setup do
-    @server = EchoServer.new({ :ready_timeout => 0.1 })
+    @server = EchoServer.new({ :ready_timeout => 0.1, :debug => !!ENV['DEBUG'] })
   end
 
   should "have started a separate thread for running the server" do

--- a/test/unit/worker_pool_test.rb
+++ b/test/unit/worker_pool_test.rb
@@ -9,9 +9,8 @@ class DatTCP::WorkerPool
     end
     subject{ @work_pool }
 
-    should have_instance_methods :logger, :mutex, :cond, :spawned, :waiting
-    should have_instance_methods :enqueue_connection, :shutdown
-    should have_instance_methods :on_worker_waiting, :on_worker_stop_waiting, :on_worker_shutdown
+    should have_instance_methods :logger, :enqueue_connection, :shutdown
+    should have_instance_methods :despawn_worker, :spawned, :waiting
 
   end
 


### PR DESCRIPTION
This changes DatTCP to be more efficient and not spin a thread up
for every connection. Instead it will spin up threads (to a
maximum) and leave them going to continue processing connections.
This is more efficient and keeps us from continually creating
threads. This, plus removing any 'serving' logging (even null
logging), made the server faster and smoother.
- The `WorkerPool` no longer 'processes' connections. It adds
  them to it's queue and signals any workers who are waiting.
- Workers are spawned and, if no connections are queued up, they
  become idle waiting. Once a connection is added, they will
  pick it up and serve it.
- If a connection is added and no worker is available to pick it
  up, then a new one will be spawned if the pool hasn't reached
  it's maximum allowed.
- Shutting down a pool will allow any connections that have been
  picked up by a worker to finish processing. Connections on the
  queue will not be served.

@kellyredding - This implements proper management of threads with the `WorkerPool`. Based on what the internet says, creating threads is expensive, so I think this is a better practice than our previous implementation. This is heavily borrowed from puma.

The overall speed is a bit misleading, because a large portion of it was due to removing logging and getting the connection's socket address. There is about a 0.3ms time shaved off the average request, about 0.2ms is due to the removal of the logging. About 0.1ms was gained from the thread management changes.
