### PR TITLE
Add hook for configuring the TCP server

### DIFF
--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -61,7 +61,7 @@ module DatTCP
       run_hook 'on_listen'
       @tcp_server = TCPServer.new(ip, port)
       @tcp_server.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, true)
-      # TODO - configure TCPServer hook
+      run_hook 'configure_tcp_server', @tcp_server
       @tcp_server.listen(@backlog_size)
     end
 
@@ -110,6 +110,9 @@ module DatTCP
     # Hooks
 
     def on_listen
+    end
+
+    def configure_tcp_server(tcp_server)
     end
 
     def on_run
@@ -190,8 +193,8 @@ module DatTCP
       @work_loop_thread.join if @work_loop_thread
     end
 
-    def run_hook(method)
-      self.send(method)
+    def run_hook(method, *args)
+      self.send(method, *args)
     end
 
     def set_state(name)

--- a/test/support/test_server.rb
+++ b/test/support/test_server.rb
@@ -2,10 +2,14 @@ class TestServer
   include DatTCP::Server
 
   attr_reader :on_listen_called, :on_run_called, :on_pause_called,
-    :on_stop_called, :on_halt_called
+    :on_stop_called, :on_halt_called, :configure_tcp_server_called
 
   def on_listen
     @on_listen_called = true
+  end
+
+  def configure_tcp_server(tcp_server)
+    @configure_tcp_server_called = tcp_server
   end
 
   def on_run

--- a/test/unit/dat-tcp_test.rb
+++ b/test/unit/dat-tcp_test.rb
@@ -49,6 +49,7 @@ module DatTCP
 
     should "have called on_listen but no other hooks" do
       assert_equal true, subject.on_listen_called
+      assert_instance_of TCPServer, subject.configure_tcp_server_called
       assert_nil subject.on_run_called
       assert_nil subject.on_pause_called
       assert_nil subject.on_stop_called
@@ -85,6 +86,7 @@ module DatTCP
 
     should "have called on_listen and on_run but no other hooks" do
       assert_equal true, subject.on_listen_called
+      assert_instance_of TCPServer, subject.configure_tcp_server_called
       assert_equal true, subject.on_run_called
       assert_nil subject.on_pause_called
       assert_nil subject.on_stop_called
@@ -114,6 +116,7 @@ module DatTCP
 
     should "have called on_listen, on_run and on_pause but no other hooks" do
       assert_equal true, subject.on_listen_called
+      assert_instance_of TCPServer, subject.configure_tcp_server_called
       assert_equal true, subject.on_run_called
       assert_equal true, subject.on_pause_called
       assert_nil subject.on_stop_called
@@ -140,6 +143,7 @@ module DatTCP
 
     should "have called on_listen, on_run and on_pause but no other hooks" do
       assert_equal true, subject.on_listen_called
+      assert_instance_of TCPServer, subject.configure_tcp_server_called
       assert_equal true, subject.on_run_called
       assert_nil subject.on_pause_called
       assert_equal true, subject.on_stop_called
@@ -166,6 +170,7 @@ module DatTCP
 
     should "have called on_listen, on_run and on_pause but no other hooks" do
       assert_equal true, subject.on_listen_called
+      assert_instance_of TCPServer, subject.configure_tcp_server_called
       assert_equal true, subject.on_run_called
       assert_nil subject.on_pause_called
       assert_nil subject.on_stop_called


### PR DESCRIPTION
This adds a defined hook where a DatTCP server's TCP server can
be configured. This is so socket options can be set to customize
the TCP server without having to hack it in somewhere else.
