### PR TITLE
Added a timeout when shutting down the worker pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,21 @@ $ kill -TERM 12345
 
 ### Configuration
 
-* `backlog_size`  - The number of connections that can be pending. These are
-                    connections that haven't been 'accepted' by the server.
-* `min_workers`   - The minimum number of threads available to handle connections
-* `max_workers`   - The maximum number of threads to spin up to handle connections.
-* `ready_timeout` - The number of seconds the server will wait for a new
-                    connection. This controls the "responsiveness" of the
-                    server; how fast it will perform checks, like detecting if
-                    it has been signaled to stop.
-* `debug`         - Output debug messages or not.
+* `backlog_size`     - The number of connections that can be pending. These
+                       are connections that haven't been 'accepted' by the
+                       server.
+* `min_workers`      - The minimum number of threads available to handle
+                       connections.
+* `max_workers`      - The maximum number of threads to spin up to handle
+                       connections.
+* `ready_timeout`    - The number of seconds the server will wait for a new
+                       connection. This controls the "responsiveness" of the
+                       server; how fast it will perform checks, like detecting
+                       if it has been signaled to stop.
+* `shutdown_timeout` - The number of seconds the server will wait for workers
+                       to finish serving a connection. If they don't finish in
+                       this time, the server will continue shutting down.
+* `debug`            - Output debug messages or not.
 
 ### Hooks
 

--- a/dat-tcp.gemspec
+++ b/dat-tcp.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency("SystemTimer", ["~> 1.2"])
+
   gem.add_development_dependency('assert',        ['~> 1.0'])
   gem.add_development_dependency('assert-mocha',  ['~> 1.0'])
 end

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -16,11 +16,12 @@ module DatTCP
 
     def initialize(config = nil)
       config = OpenStruct.new(config || {})
-      @backlog_size  = config.backlog_size  || 1024
-      @debug         = config.debug         || false
-      @min_workers   = config.min_workers   || 2
-      @max_workers   = config.max_workers   || 4
-      @ready_timeout = config.ready_timeout || 1
+      @backlog_size     = config.backlog_size     || 1024
+      @debug            = config.debug            || false
+      @min_workers      = config.min_workers      || 2
+      @max_workers      = config.max_workers      || 4
+      @ready_timeout    = config.ready_timeout    || 1
+      @shutdown_timeout = config.shutdown_timeout || 15
 
       @logger = DatTCP::Logger.new(@debug)
 
@@ -195,7 +196,7 @@ module DatTCP
 
     def shutdown_worker_pool
       self.logger.info "Shutting down worker pool, letting it finish..."
-      @worker_pool.shutdown
+      @worker_pool.shutdown(@pool_shutdown_timeout)
     end
 
     def close_connection


### PR DESCRIPTION
This adds system timer to timeout the worker pool when it is
shutting down. If a worker is stuck in a neverending loop then
the server can never gracefully shutdown. This forces a
configurable timeout on waiting for workers to finish. If the
workers don't finish, then the server will stop waiting and
continue shutting down. This will most likely cause the threads
to be terminated in the middle of their serving a connection.

Closes #5 

@kellyredding - After seeing the deadlock issue we ran into, I'd prefer going ahead and having this in DatTCP.
