### PR TITLE
Don't validate that min workers is less than max workers

### DIFF
--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -22,15 +22,13 @@ module DatTCP
 
       @logger = DatTCP::Logger.new(@debug)
 
-      check_configuration
-
       @tcp_server       = nil
       @work_loop_thread = nil
       @worker_pool      = nil
       set_state :stop
     end
 
-    # Socket Options:
+    # `setsockopt` values:
     # * SOL_SOCKET   - specifies the protocol layer the option applies to.
     #                  SOL_SOCKET is basic socket options (as opposed to
     #                  something like IPPROTO_TCP for TCP socket options).
@@ -40,7 +38,6 @@ module DatTCP
     #                  were shutdown and started right away. This will still
     #                  throw an "address in use" if a socket is active on the
     #                  port.
-
     def listen(*args)
       set_state :listen
       run_hook 'on_listen'
@@ -206,14 +203,6 @@ module DatTCP
 
     def wait_for_shutdown
       @work_loop_thread.join if @work_loop_thread
-    end
-
-    def check_configuration
-      if @min_workers > @max_workers
-        self.logger.warn "The minimum number of workers (#{@min_workers}) " \
-                         "is greater than " \
-                         "the maximum number of workers (#{@max_workers})."
-      end
     end
 
     def run_hook(method, *args)


### PR DESCRIPTION
This removes the validation for a DatTCP server that would ensure
the min workers is less than the max workers. With DatWorkerPool
being it's own gem, this is it's responsiblity and not DatTCPs.
Futhermore, DatTCP/DatWorkerPool will run if the min workers are
more than the max workers. The behavior may be strange, but if
you configure it with bad data you should get bad behavior.

Apparently we were not testing this feature either, which is
another good reason to remove it.

Closes #24
