### PR TITLE
Rename the `run` command to `start`

### DIFF
--- a/bench/server.rb
+++ b/bench/server.rb
@@ -15,7 +15,7 @@ module Bench
 
     def start(*args)
       @server.listen(*args)
-      @server.run.join
+      @server.start.join
     end
 
     def stop

--- a/test/support/echo_server.rb
+++ b/test/support/echo_server.rb
@@ -14,7 +14,7 @@ module EchoServer
         pid = fork do
           server.listen(*args)
           trap("TERM"){ server.stop }
-          server.run.join
+          server.start.join
         end
         sleep 0.3 # Give time for the socket to start listening.
         yield

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -12,15 +12,16 @@ class EchoServerTests < Assert::Context
   setup do
     @server = EchoServer.new({ :ready_timeout => 0.1, :debug => !!ENV['DEBUG'] })
   end
+  teardown do
+    @server.stop
+  end
 
   should "have started a separate thread for running the server" do
     @server.listen('localhost', 56789)
-    thread = @server.run
+    thread = @server.start
 
     assert_instance_of Thread, thread
     assert thread.alive?
-
-    @server.stop
   end
 
   should "be able to connect, send messages and have them echoed back" do


### PR DESCRIPTION
This renames the `run` command to `start`. This is more congruent
with the other commands and is a better opposite to `stop`. This
is also to be consistent with `Qs` command naming scheme.

Closes #20
