### PR TITLE
Change the `wait_for_shutdown` default from true to false

### DIFF
--- a/bench/server.rb
+++ b/bench/server.rb
@@ -19,7 +19,7 @@ module Bench
     end
 
     def stop
-      @server.stop
+      @server.stop true
     end
 
     def serve(socket)

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -60,19 +60,19 @@ module DatTCP
       @work_loop_thread = Thread.new{ work_loop(client_file_descriptors) }
     end
 
-    def pause(wait = true)
+    def pause(wait = false)
       set_state :pause
       run_hook 'on_pause'
       wait_for_shutdown if wait
     end
 
-    def stop(wait = true)
+    def stop(wait = false)
       set_state :stop
       run_hook 'on_stop'
       wait_for_shutdown if wait
     end
 
-    def halt(wait = true)
+    def halt(wait = false)
       set_state :halt
       run_hook 'on_halt'
       wait_for_shutdown if wait

--- a/test/support/echo_server.rb
+++ b/test/support/echo_server.rb
@@ -13,7 +13,7 @@ module EchoServer
       begin
         pid = fork do
           server.listen(*args)
-          trap("TERM"){ server.stop }
+          trap("TERM"){ server.stop(true) }
           server.start.join
         end
         sleep 0.3 # Give time for the socket to start listening.

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -13,7 +13,7 @@ class EchoServerTests < Assert::Context
     @server = EchoServer.new({ :ready_timeout => 0.1, :debug => !!ENV['DEBUG'] })
   end
   teardown do
-    @server.stop
+    @server.stop true
   end
 
   should "have started a separate thread for running the server" do

--- a/test/unit/dat-tcp_tests.rb
+++ b/test/unit/dat-tcp_tests.rb
@@ -88,7 +88,7 @@ module DatTCP
       @thread = @server.start
     end
     teardown do
-      @server.stop
+      @server.stop true
       @thread.join
     end
 
@@ -119,7 +119,7 @@ module DatTCP
     setup do
       @server.listen('localhost', 45678)
       @thread = @server.start
-      @server.pause
+      @server.pause true
       @thread.join
     end
     teardown do
@@ -152,7 +152,7 @@ module DatTCP
     setup do
       @server.listen('localhost', 45678)
       @thread = @server.start
-      @server.stop
+      @server.stop true
       @thread.join
     end
 
@@ -182,7 +182,7 @@ module DatTCP
     setup do
       @server.listen('localhost', 45678)
       @thread = @server.start
-      @server.halt
+      @server.halt true
       @thread.join
     end
 
@@ -223,7 +223,7 @@ module DatTCP
     end
     teardown do
       @client_socket.close
-      @server.stop
+      @server.stop true
       @thread.join
     end
 
@@ -252,7 +252,7 @@ module DatTCP
       assert_equal 'handled', value
 
       @server.stop_listening
-      new_server.stop
+      new_server.stop true
       thread.join
     end
 


### PR DESCRIPTION
The main reasoning for originallying defaulting it to true was
because of the test suite (where we typically want to ensure a
server shuts down before moving on). This is not a good use-case
for a default though. The more common case in actual usage is to
not wait for shutdown. This was evident when writing `Sanford`
and while working on `Qs`. This lines up this behavior so it is
consistent with how `Qs` works.
