### PR TITLE
Remove `accept_connection` loop, not needed

### DIFF
--- a/test/unit/dat-tcp_tests.rb
+++ b/test/unit/dat-tcp_tests.rb
@@ -217,7 +217,7 @@ module DatTCP
       @thread.join(0.5) # give the server a chance to queue the connection
     end
     teardown do
-      @client_socket.close
+      @client_socket.close rescue false
       @server.stop true
       @thread.join
     end


### PR DESCRIPTION
This removes the while loop in the `accept_connection` method.
This is ultimately not-needed and just creates extra overhead.
I'm not sure why I originally thought this was needed, but it's
a loop within a loop that both have the same conditions. This
might have been due to legacy concerns. This is a simpler
implementation that achieves the same functionality.
