### PR TITLE
Use self-pipe trick for stopping, halting and pausing

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Making 10000 request(s):
 ....................................................................................................
-Total Time:   1859.1179ms
-Average Time:    0.1859ms
-Min Time:        0.1499ms
-Max Time:       27.2200ms
+Total Time:   1825.9748ms
+Average Time:    0.1825ms
+Min Time:        0.1490ms
+Max Time:       24.2550ms
 
 Done running benchmark report

--- a/bench/server.rb
+++ b/bench/server.rb
@@ -19,7 +19,7 @@ module Bench
     end
 
     def stop
-      @server.stop true
+      @server.stop
     end
 
     def serve(socket)

--- a/bench/server_report.txt
+++ b/bench/server_report.txt
@@ -1,6 +1,6 @@
 Server statistics
-  Total Time:     0.4283ms
+  Total Time:     0.4808ms
   Average Time:   0.0000ms
   Min Time:       0.0000ms
-  Max Time:       0.0040ms
+  Max Time:       0.0240ms
 

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -10,7 +10,7 @@ class EchoServerTests < Assert::Context
 
   desc "defining a custom Echo Server"
   setup do
-    @server = EchoServer.new({ :ready_timeout => 0.1, :debug => !!ENV['DEBUG'] })
+    @server = EchoServer.new({ :debug => !!ENV['DEBUG'] })
   end
   teardown do
     @server.stop true


### PR DESCRIPTION
This switches the server's work loop to `IO.select` a pipe along
with the `TCPServer`. The pipe is used to "wakeup" the work loop
so that it can exit. This allows removing the timeout that was
passed to `IO.select` and makes the server immediately responsive
to signals. When trapping signals, the `stop`, `halt` or `pause`
methods should be called. These will write to the pipe and exit.
This wakes up the work loop. It will then read from the pipe and
set it's signal appropriately. This also makes calling the
command methods safe in signal blocks (as long as you don't wait
for the server to shutdown).

Closes #17
