### PR TITLE
switch to the latest assert for test stubbing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"

--- a/dat-tcp.gemspec
+++ b/dat-tcp.gemspec
@@ -21,6 +21,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("dat-worker-pool", ["~> 0.3"])
 
-  gem.add_development_dependency('assert',        ['~> 2.3'])
-  gem.add_development_dependency('assert-mocha',  ['~> 1.0'])
+  gem.add_development_dependency('assert', ['~> 2.11'])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,5 +6,3 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
-
-require 'assert-mocha' if defined?(Assert)


### PR DESCRIPTION
The latest assert adds its own native stubbing API. The switches
to that. No behavior changes - just test cleanups.

@jcredding ready for review.
