### PR TITLE
Add a `ServerSpy` for testing

### DIFF
--- a/lib/dat-tcp/server_spy.rb
+++ b/lib/dat-tcp/server_spy.rb
@@ -1,0 +1,82 @@
+require 'dat-tcp/logger'
+
+module DatTCP
+
+  class ServerSpy
+
+    attr_reader :ip, :port, :file_descriptor
+    attr_reader :client_file_descriptors
+    attr_reader :logger
+    attr_reader :waiting_for_pause, :waiting_for_stop, :waiting_for_halt
+    attr_accessor :listen_called, :start_called
+    attr_accessor :stop_listen_called, :pause_called
+    attr_accessor :stop_called, :halt_called
+
+    attr_accessor :serve_proc
+
+    def initialize
+      @ip = nil
+      @port = nil
+      @file_descriptor = nil
+      @client_file_descriptors = []
+      @logger = DatTCP::Logger::Null.new
+
+      @waiting_for_pause = nil
+      @waiting_for_stop = nil
+      @waiting_for_hale = nil
+
+      @listen_called = false
+      @stop_listen_called = false
+      @start_called = false
+      @pause_called = false
+      @stop_called = false
+      @halt_called = false
+
+      @serve_proc = proc{ }
+    end
+
+    def listening?
+      @listen_called && !@stop_listen_called
+    end
+
+    def running?
+      @start_called && !(@pause_called || @stop_called || @halt_called)
+    end
+
+    def listen(*args)
+      case args.size
+      when 2
+        @ip, @port = args
+      when 1
+        @file_descriptor = args.first
+      end
+      @listen_called = true
+    end
+
+    def stop_listen
+      @stop_listen_called = true
+    end
+
+    def start(client_file_descriptors = nil)
+      @client_file_descriptors = client_file_descriptors || []
+      @start_called = true
+    end
+
+    def pause(wait = false)
+      @waiting_for_pause = wait
+      @pause_called = true
+    end
+
+    def stop(wait = false)
+      @waiting_for_stop = wait
+      @stop_called = true
+    end
+
+    def halt(wait = false)
+      @waiting_for_halt = wait
+      @halt_called = true
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,3 +6,5 @@ $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 # require pry for debugging (`binding.pry`)
 require 'pry'
+
+require 'test/support/factory'

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/unit/server_spy_tests.rb
+++ b/test/unit/server_spy_tests.rb
@@ -1,0 +1,136 @@
+require 'assert'
+require 'dat-tcp/server_spy'
+
+class DatTCP::ServerSpy
+
+  class UnitTests < Assert::Context
+    desc "DatTCP::ServerSpy"
+    setup do
+      @server_spy = DatTCP::ServerSpy.new
+    end
+    subject{ @server_spy }
+
+    should have_readers :ip, :port, :file_descriptor
+    should have_readers :client_file_descriptors
+    should have_readers :logger
+    should have_readers :waiting_for_pause
+    should have_readers :waiting_for_stop, :waiting_for_halt
+    should have_readers :listen_called, :start_called
+    should have_readers :stop_listen_called, :pause_called
+    should have_readers :stop_called, :halt_called
+    should have_accessors :serve_proc
+    should have_imeths :listening?, :running?
+    should have_imeths :listen, :stop_listen
+    should have_imeths :start, :stop, :halt
+
+    should "default its attributes" do
+      assert_nil subject.ip
+      assert_nil subject.port
+      assert_nil subject.file_descriptor
+      assert_equal [], subject.client_file_descriptors
+      assert_instance_of DatTCP::Logger::Null, subject.logger
+
+      assert_nil subject.waiting_for_pause
+      assert_nil subject.waiting_for_stop
+      assert_nil subject.waiting_for_halt
+
+      assert_false subject.listen_called
+      assert_false subject.stop_listen_called
+      assert_false subject.start_called
+      assert_false subject.pause_called
+      assert_false subject.stop_called
+      assert_false subject.halt_called
+
+      assert_instance_of Proc, subject.serve_proc
+    end
+
+    should "know if its listening or not" do
+      assert_false subject.listening?
+      subject.listen(Factory.integer)
+      assert_true subject.listening?
+      subject.stop_listen
+      assert_false subject.listening?
+    end
+
+    should "know if its running or not" do
+      assert_false subject.running?
+      subject.start
+      assert_true subject.running?
+
+      subject.pause
+      assert_false subject.running?
+      subject.pause_called = false
+
+      subject.stop
+      assert_false subject.running?
+      subject.stop_called = false
+
+      subject.halt
+      assert_false subject.running?
+    end
+
+    should "set its ip, port and listen flag using `listen`" do
+      ip = Factory.string
+      port = Factory.integer
+
+      assert_false subject.listen_called
+      subject.listen(ip, port)
+      assert_equal ip, subject.ip
+      assert_equal port, subject.port
+      assert_true subject.listen_called
+    end
+
+    should "set its file descriptor and listen flag using `listen`" do
+      fd = Factory.integer
+
+      assert_false subject.listen_called
+      subject.listen(fd)
+      assert_equal fd, subject.file_descriptor
+      assert_true subject.listen_called
+    end
+
+    should "set its stop listen flag using `stop_listen`" do
+      assert_false subject.stop_listen_called
+      subject.stop_listen
+      assert_true subject.stop_listen_called
+    end
+
+    should "set its client file descriptors and its start flag using `start`" do
+      client_fds = [ Factory.integer, Factory.integer ]
+
+      assert_false subject.start_called
+      subject.start(client_fds)
+      assert_equal client_fds, subject.client_file_descriptors
+      assert_true subject.start_called
+    end
+
+    should "set its waiting for pause and pause called flag using `pause`" do
+      wait = Factory.boolean
+
+      assert_false subject.pause_called
+      subject.pause(wait)
+      assert_equal wait, subject.waiting_for_pause
+      assert_true subject.pause_called
+    end
+
+    should "set its waiting for stop and stop called flag using `stop`" do
+      wait = Factory.boolean
+
+      assert_false subject.stop_called
+      subject.stop(wait)
+      assert_equal wait, subject.waiting_for_stop
+      assert_true subject.stop_called
+    end
+
+    should "set its waiting for halt and halt called flag using `halt`" do
+      wait = Factory.boolean
+
+      assert_false subject.halt_called
+      subject.halt(wait)
+      assert_equal wait, subject.waiting_for_halt
+      assert_true subject.halt_called
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `ServerSpy` that has the same interface as a
`Server` but doesn't use a real TCP server or do any kind of
processing connections. The class acts as a spy and will store
off the calls made to it. This is useful for dependency injecting
into tests to get the interface of a server without trying to
work with a real TCP server. It also allows testing what calls
were made to it to ensure a DatTCP server is being built as
expected.

This also sets up a factory for the tests using asserts factory.
This should be used to help generate random data.

@kellyredding - Ready for review.
