### PR TITLE
Update to the latest `DatWorkerPool`

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Making 10000 request(s):
 ....................................................................................................
-Total Time:   2009.8336ms
-Average Time:    0.2009ms
-Min Time:        0.1661ms
-Max Time:      129.1110ms
+Total Time:   1969.0921ms
+Average Time:    0.1969ms
+Min Time:        0.1649ms
+Max Time:      128.3750ms
 
 Done running benchmark report

--- a/bench/server_report.txt
+++ b/bench/server_report.txt
@@ -1,6 +1,6 @@
 Server statistics
-  Total Time:     0.4593ms
+  Total Time:     0.5878ms
   Average Time:   0.0000ms
   Min Time:       0.0000ms
-  Max Time:       0.0042ms
+  Max Time:       0.1281ms
 

--- a/dat-tcp.gemspec
+++ b/dat-tcp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-worker-pool", ["~> 0.3"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.4"])
 
-  gem.add_development_dependency('assert', ['~> 2.11'])
+  gem.add_development_dependency('assert', ['~> 2.12'])
 end

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -111,6 +111,7 @@ module DatTCP
         serve(socket)
       end
       add_client_sockets_from_fds client_file_descriptors
+      @worker_pool.start
       process_inputs while @signal.start?
       logger.info "Stopping work loop..."
       shutdown_worker_pool unless @signal.halt?


### PR DESCRIPTION
This updates `DatTCP` to work with the latest `DatWorkerPool`. This
involved calling the `start` method on the worker pool after its
been created. Previously, it automatically started when it was
built. This also runs the benchmarks to ensure there are no
performance degradations.

@kellyredding - Ready for review.