### PR TITLE
Change the ip method to return the socket ip not its hostname

### DIFF
--- a/dat-tcp.gemspec
+++ b/dat-tcp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-worker-pool", ["~> 0.4"])
+  gem.add_dependency("dat-worker-pool", ["~> 0.5"])
 
-  gem.add_development_dependency('assert', ['~> 2.12'])
+  gem.add_development_dependency('assert', ['~> 2.15'])
 end

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -31,7 +31,7 @@ module DatTCP
     end
 
     def ip
-      @tcp_server.addr[2] if self.listening?
+      @tcp_server.addr[3] if self.listening?
     end
 
     def port

--- a/test/support/tcp_server_spy.rb
+++ b/test/support/tcp_server_spy.rb
@@ -5,14 +5,14 @@ class TCPServerSpy
   attr_accessor :connected_sockets
 
   def initialize
-    @ip     = 'localhost'
+    @ip     = '127.0.0.1'
     @port   = 45678
     @fileno = 12345
     close
   end
 
   def addr
-    [ 'family', @port, @ip, 'numeric-address' ]
+    ['family', @port, 'hostname', @ip]
   end
 
   def setsockopt(level, name, value)

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -17,7 +17,7 @@ class EchoServerTests < Assert::Context
   end
 
   should "have started a separate thread for running the server" do
-    @server.listen('localhost', 56789)
+    @server.listen('127.0.0.1', 56789)
     thread = @server.start
 
     assert_instance_of Thread, thread
@@ -25,11 +25,11 @@ class EchoServerTests < Assert::Context
   end
 
   should "be able to connect, send messages and have them echoed back" do
-    self.start_server(@server, 'localhost', 56789) do
+    self.start_server(@server, '127.0.0.1', 56789) do
       begin
         client = nil
         assert_nothing_raised do
-          client = TCPSocket.open('localhost', 56789)
+          client = TCPSocket.open('127.0.0.1', 56789)
         end
 
         client.write('Test')


### PR DESCRIPTION
This changes the ip method to return the socket ip not its
hostname. This more closely matches the method name. A hostname
can still be used when calling `listen`.

This showed up in Sanfords test suite. I wanted to switch to using
`127.0.0.1` instead of `localhost` because there are situations
where a computer has trouble looking up an ip for a hostname and
that causes the test suite to fail. I couldn't switch everything
though because one of the tests expected the ip being passed to
`listen` to be returned with the `ip` method but it returned
`localhost`. This confused me because the method is called `ip`
so I didn't immediately understand why it would return the hostname
instead.

@kellyredding - Ready for review.