### PR TITLE
Update to use the new dat-worker-pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ gemspec
 
 gem 'rake'
 gem 'pry', "~> 0.9.0"
+
+gem 'dat-worker-pool', :path => "~/Projects/redding/gems/dat-worker-pool"

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Making 10000 request(s):
 ....................................................................................................
-Total Time:   3754.6409ms
-Average Time:    0.3754ms
-Min Time:        0.2088ms
-Max Time:       57.9419ms
+Total Time:   3719.6049ms
+Average Time:    0.3719ms
+Min Time:        0.2250ms
+Max Time:       48.9699ms
 
 Done running benchmark report

--- a/bench/runner.rb
+++ b/bench/runner.rb
@@ -3,7 +3,7 @@ require 'benchmark'
 module Bench
 
   class Runner
-    HOST_AND_PORT = [ '0.0.0.0', 12000 ]
+    HOST_AND_PORT = ['0.0.0.0', 12000]
 
     TIME_MODIFIER = 10 ** 4 # 4 decimal places
 
@@ -31,7 +31,7 @@ module Bench
 
     def display_time(time)
       integer, fractional = time.to_s.split('.')
-      [ integer, fractional.ljust(4, '0') ].join('.')
+      [integer, fractional.ljust(4, '0')].join('.')
     end
 
   end

--- a/bench/server_report.txt
+++ b/bench/server_report.txt
@@ -1,6 +1,6 @@
 Server statistics
-  Total Time:     0.5441ms
+  Total Time:     0.4717ms
   Average Time:   0.0000ms
   Min Time:       0.0000ms
-  Max Time:       0.0068ms
+  Max Time:       0.0037ms
 

--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -4,37 +4,39 @@ require 'thread'
 
 require 'dat-tcp/version'
 require 'dat-tcp/logger'
+require 'dat-tcp/worker'
 
 module DatTCP
 
   class Server
 
-    attr_reader :worker_start_procs, :worker_shutdown_procs
-    attr_reader :worker_sleep_procs, :worker_wakeup_procs
+    DEFAULT_NUM_WORKERS = 2
+
     attr_reader :logger
     private :logger
 
-    def initialize(config = nil, &serve_proc)
-      config ||= {}
-      @backlog_size     = config[:backlog_size]     || 1024
-      @debug            = config[:debug]            || false
-      @min_workers      = config[:min_workers]      || 2
-      @max_workers      = config[:max_workers]      || 4
-      @shutdown_timeout = config[:shutdown_timeout] || 15
-      @signal_reader, @signal_writer = IO.pipe
-      @serve_proc = serve_proc || raise(ArgumentError, "no block given")
+    def initialize(worker_class, options = nil)
+      if !worker_class.kind_of?(Class) || !worker_class.include?(DatTCP::Worker)
+        raise ArgumentError, "worker class must include `#{DatTCP::Worker}`"
+      end
 
-      @worker_start_procs    = []
-      @worker_shutdown_procs = []
-      @worker_sleep_procs    = []
-      @worker_wakeup_procs   = []
+      options ||= {}
+      @backlog_size     = options[:backlog_size]     || 1024
+      @debug            = options[:debug]            || false
+      @shutdown_timeout = options[:shutdown_timeout] || 15
+
+      @signal_reader, @signal_writer = IO.pipe
 
       @logger = DatTCP::Logger.new(@debug)
 
-      @tcp_server       = nil
-      @work_loop_thread = nil
-      @worker_pool      = nil
-      @signal = Signal.new(:stop)
+      @worker_pool = DatWorkerPool.new(worker_class, {
+        :num_workers   => (options[:num_workers] || DEFAULT_NUM_WORKERS),
+        :worker_params => options[:worker_params]
+      })
+
+      @tcp_server = nil
+      @thread     = nil
+      @signal     = Signal.new(:stop)
     end
 
     def ip
@@ -50,7 +52,7 @@ module DatTCP
     end
 
     def client_file_descriptors
-      @worker_pool ? @worker_pool.work_items.map(&:fileno) : []
+      @worker_pool.work_items.map(&:fileno)
     end
 
     def listening?
@@ -58,7 +60,7 @@ module DatTCP
     end
 
     def running?
-      !!(@work_loop_thread && @work_loop_thread.alive?)
+      !!(@thread && @thread.alive?)
     end
 
     def listen(*args)
@@ -74,10 +76,10 @@ module DatTCP
       @tcp_server = nil
     end
 
-    def start(client_file_descriptors = nil)
+    def start(passed_client_fds = nil)
       raise NotListeningError.new unless listening?
       @signal.set :start
-      @work_loop_thread = Thread.new{ work_loop(client_file_descriptors) }
+      @thread = Thread.new{ work_loop(passed_client_fds) }
     end
 
     def pause(wait = false)
@@ -95,103 +97,64 @@ module DatTCP
       wait_for_shutdown if wait
     end
 
-    def on_worker_start(&block);    @worker_start_procs << block;    end
-    def on_worker_shutdown(&block); @worker_shutdown_procs << block; end
-    def on_worker_sleep(&block);    @worker_sleep_procs << block;    end
-    def on_worker_wakeup(&block);   @worker_wakeup_procs << block;   end
-
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference}".tap do |s|
         s << " @ip=#{ip.inspect} @port=#{port.inspect}"
-        s << " @work_loop_status=#{@work_loop_thread.status.inspect}" if running?
         s << ">"
       end
     end
 
     private
 
-    def serve(socket)
-      @serve_proc.call(socket)
-    ensure
-      socket.close rescue false
-    end
-
-    def work_loop(client_file_descriptors = nil)
-      logger.info "Starting work loop..."
-      @worker_pool = build_worker_pool
-      add_client_sockets_from_fds client_file_descriptors
-      @worker_pool.start
-      process_inputs while @signal.start?
-      logger.info "Stopping work loop..."
-      shutdown_worker_pool unless @signal.halt?
+    def work_loop(passed_client_fds)
+      setup(passed_client_fds)
+      accept_client_connections while @signal.start?
     rescue StandardError => exception
       logger.error "Exception occurred, stopping server!"
       logger.error "#{exception.class}: #{exception.message}"
       logger.error exception.backtrace.join("\n")
     ensure
+      teardown
+    end
+
+    def setup(passed_client_fds)
+      logger.info "Starting work loop..."
+      @worker_pool.start
+      (passed_client_fds || []).each do |fd|
+        @worker_pool.push TCPSocket.for_fd(fd)
+      end
+    end
+
+    def accept_client_connections
+      ready_inputs, _, _ = IO.select([@tcp_server, @signal_reader])
+
+      if ready_inputs.include?(@tcp_server)
+        @worker_pool.push @tcp_server.accept
+      end
+
+      if ready_inputs.include?(@signal_reader)
+        @signal.send @signal_reader.read_nonblock(1)
+      end
+    end
+
+    def teardown
+      logger.info "Stopping work loop..."
       unless @signal.pause?
         logger.info "Closing TCP server connection"
-        stop_listen
+        self.stop_listen
       end
-      clear_thread
+      unless @signal.halt?
+        logger.info "Shutting down worker pool"
+        @worker_pool.shutdown(@shutdown_timeout)
+      end
       logger.info "Stopped work loop"
-    end
-
-    def build_worker_pool
-      wp = DatWorkerPool.new(
-        @min_workers,
-        @max_workers
-      ){ |socket| serve(socket) }
-
-      # add any configured callbacks
-      self.worker_start_procs.each do |cb|
-        wp.on_worker_start(&cb)
-      end
-      self.worker_shutdown_procs.each do |cb|
-        wp.on_worker_shutdown(&cb)
-      end
-      self.worker_sleep_procs.each do |cb|
-        wp.on_worker_sleep(&cb)
-      end
-      self.worker_wakeup_procs.each do |cb|
-        wp.on_worker_wakeup(&cb)
-      end
-
-      wp
-    end
-
-    def add_client_sockets_from_fds(file_descriptors)
-      (file_descriptors || []).each do |file_descriptor|
-        @worker_pool.add_work TCPSocket.for_fd(file_descriptor)
-      end
-    end
-
-    def process_inputs
-      ready_inputs, _, _ = IO.select([ @tcp_server, @signal_reader ])
-      accept_connection if ready_inputs.include?(@tcp_server)
-      process_signal    if ready_inputs.include?(@signal_reader)
-    end
-
-    def accept_connection
-      @worker_pool.add_work @tcp_server.accept
-    end
-
-    def process_signal
-      @signal.send @signal_reader.read_nonblock(1)
-    end
-
-    def shutdown_worker_pool
-      logger.info "Shutting down worker pool"
-      @worker_pool.shutdown(@shutdown_timeout)
-    end
-
-    def clear_thread
-      @work_loop_thread = nil
+    ensure
+      @thread = nil
     end
 
     def wait_for_shutdown
-      @work_loop_thread.join if @work_loop_thread
+      @thread.join if @thread
     end
 
     class Signal

--- a/lib/dat-tcp/worker.rb
+++ b/lib/dat-tcp/worker.rb
@@ -1,0 +1,16 @@
+require 'dat-worker-pool/worker'
+
+module DatTCP
+
+  module Worker
+
+    def self.included(klass)
+      klass.class_eval do
+        include DatWorkerPool::Worker
+
+      end
+    end
+
+  end
+
+end

--- a/test/support/echo_server.rb
+++ b/test/support/echo_server.rb
@@ -1,9 +1,17 @@
 require 'dat-tcp'
 
 module EchoServer
-  def self.new(*args)
-    DatTCP::Server.new(*args) do |socket|
+  def self.new(options = nil)
+    DatTCP::Server.new(EchoServer::Worker, options)
+  end
+
+  class Worker
+    include DatTCP::Worker
+
+    def work!(socket)
       socket.write(socket.read)
+    ensure
+      socket.close rescue false
     end
   end
 

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -10,7 +10,7 @@ class EchoServerTests < Assert::Context
 
   desc "defining a custom Echo Server"
   setup do
-    @server = EchoServer.new({ :debug => !!ENV['DEBUG'] })
+    @server = EchoServer.new(:debug => !!ENV['DEBUG'])
   end
   teardown do
     @server.stop true
@@ -34,7 +34,7 @@ class EchoServerTests < Assert::Context
 
         client.write('Test')
         client.close_write
-        response = client.read if IO.select([ client ], nil, nil, 1)
+        response = client.read if IO.select([client], nil, nil, 1)
 
         assert_equal "Test", response
       ensure

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,23 @@
+require 'assert'
+require 'dat-tcp/worker'
+
+require 'dat-worker-pool/worker'
+
+module DatTCP::Worker
+
+  class UnitTests < Assert::Context
+    desc "DatTCP::Worker"
+    setup do
+      @worker_class = Class.new do
+        include DatTCP::Worker
+      end
+    end
+    subject{ @worker_class }
+
+    should "be a dat-worker-pool worker" do
+      assert_includes DatWorkerPool::Worker, subject
+    end
+
+  end
+
+end


### PR DESCRIPTION
This updates dat-tcp to use the new dat-worker-pool.
dat-worker-pool's interface has changed but functionally it works
the same as it previously did.

When a server is initialized it now takes a worker class and a
set of options instead of just taking options. This is because
dat-worker-pool now requires a worker class when its initialized.
A block is no longer part of the server or dat-worker-pool's
interface. The logic for processing a work item (a client socket
for dat-tcp) is now part of the worker class that is passed in.
The server also no longer takes worker callbacks, these should be
added to the worker class thats passed in.

The server now also builds a worker pool when its initialized
instead of waiting till its started. This was previously made
possible when dat-worker-pool was changed to not start
automatically but dat-tcp didn't take advantage of it til now.
This avoids some conditionals and having to set/unset the worker
pool ivar as the server is started/stopped.

As part of this change, dat-tcp now also provides a `Worker` mixin
which for now only brings in dat-worker-pools `Worker` mixin. It
also requires the worker class that is passed to the server use
this mixin.

This also includes a number of small changes related to using the
new dat-worker-pool and the server interface changing:

* The server no longer automatically closes the client socket. This
  is alittle aggressive for something as generic as dat-tcp. Not
  all servers will always want to do this and it doesn't work
  nicely with the new worker class pattern of dat-worker-pool.
* The server no longer takes a min and max number of workers
  because dat-worker-pool no longer supports a min or max. It now
  defaults to 2 workers (its previous min value).
* Renamed the passed in client file descriptors. This confused me
  because the local variable and the method were the same name.
* Removed the thread status from the inspect. I'd rather not expose
  this level of detail about how the server works.
* Changed the work loop organization to try and make it more
  readable. I didn't find it very approachable when I was trying to
  understand its logic.
* Updated styles and conventions to our latest standards
  throughout.

@kellyredding - Ready for review.