### PR TITLE
Update server spy to new server interface

### DIFF
--- a/lib/dat-tcp.rb
+++ b/lib/dat-tcp.rb
@@ -9,7 +9,9 @@ module DatTCP
 
   class Server
 
-    DEFAULT_NUM_WORKERS = 2
+    DEFAULT_BACKLOG_SIZE     = 1024
+    DEFAULT_SHUTDOWN_TIMEOUT = 15
+    DEFAULT_NUM_WORKERS      = 2
 
     def initialize(worker_class, options = nil)
       if !worker_class.kind_of?(Class) || !worker_class.include?(DatTCP::Worker)
@@ -17,8 +19,8 @@ module DatTCP
       end
 
       options ||= {}
-      @backlog_size     = options[:backlog_size]     || 1024
-      @shutdown_timeout = options[:shutdown_timeout] || 15
+      @backlog_size     = options[:backlog_size]     || DEFAULT_BACKLOG_SIZE
+      @shutdown_timeout = options[:shutdown_timeout] || DEFAULT_SHUTDOWN_TIMEOUT
 
       @signal_reader, @signal_writer = IO.pipe
 

--- a/lib/dat-tcp/server_spy.rb
+++ b/lib/dat-tcp/server_spy.rb
@@ -1,41 +1,49 @@
+require 'dat-tcp'
+require 'dat-tcp/worker'
+
 module DatTCP
 
   class ServerSpy
 
+    attr_reader :worker_class
+    attr_reader :options, :backlog_size, :shutdown_timeout
+    attr_reader :num_workers, :logger, :worker_params
     attr_reader :ip, :port, :file_descriptor
     attr_reader :client_file_descriptors
-    attr_reader :worker_start_procs, :worker_shutdown_procs
-    attr_reader :worker_sleep_procs, :worker_wakeup_procs
     attr_reader :waiting_for_pause, :waiting_for_stop, :waiting_for_halt
     attr_accessor :listen_called, :start_called
     attr_accessor :stop_listen_called, :pause_called
     attr_accessor :stop_called, :halt_called
 
-    attr_accessor :serve_proc
+    def initialize(worker_class, options = nil)
+      @worker_class = worker_class
+      if !@worker_class.kind_of?(Class) || !@worker_class.include?(DatTCP::Worker)
+        raise ArgumentError, "worker class must include `#{DatTCP::Worker}`"
+      end
 
-    def initialize
-      @ip = nil
-      @port = nil
-      @file_descriptor = nil
+      server_ns = DatTCP::Server
+      @options          = options || {}
+      @backlog_size     = @options[:backlog_size]     || server_ns::DEFAULT_BACKLOG_SIZE
+      @shutdown_timeout = @options[:shutdown_timeout] || server_ns::DEFAULT_SHUTDOWN_TIMEOUT
+      @num_workers      = (@options[:num_workers]     || server_ns::DEFAULT_NUM_WORKERS).to_i
+      @logger           = @options[:logger]
+      @worker_params    = @options[:worker_params]
+
+      @ip                      = nil
+      @port                    = nil
+      @file_descriptor         = nil
       @client_file_descriptors = []
 
-      @worker_start_procs    = []
-      @worker_shutdown_procs = []
-      @worker_sleep_procs    = []
-      @worker_wakeup_procs   = []
-
       @waiting_for_pause = nil
-      @waiting_for_stop = nil
-      @waiting_for_halt = nil
+      @waiting_for_stop  = nil
+      @waiting_for_halt  = nil
 
-      @listen_called = false
+      @listen_called      = false
       @stop_listen_called = false
-      @start_called = false
-      @pause_called = false
-      @stop_called = false
-      @halt_called = false
-
-      @serve_proc = proc{ }
+      @start_called       = false
+      @pause_called       = false
+      @stop_called        = false
+      @halt_called        = false
     end
 
     def listening?
@@ -60,8 +68,8 @@ module DatTCP
       @stop_listen_called = true
     end
 
-    def start(client_file_descriptors = nil)
-      @client_file_descriptors = client_file_descriptors || []
+    def start(passed_client_fds = nil)
+      @client_file_descriptors = passed_client_fds || []
       @start_called = true
     end
 
@@ -79,11 +87,6 @@ module DatTCP
       @waiting_for_halt = wait
       @halt_called = true
     end
-
-    def on_worker_start(&block);    @worker_start_procs << block;    end
-    def on_worker_shutdown(&block); @worker_shutdown_procs << block; end
-    def on_worker_sleep(&block);    @worker_sleep_procs << block;    end
-    def on_worker_wakeup(&block);   @worker_wakeup_procs << block;   end
 
   end
 

--- a/test/unit/dat-tcp_tests.rb
+++ b/test/unit/dat-tcp_tests.rb
@@ -15,6 +15,14 @@ class DatTCP::Server
     end
     subject{ @server_class }
 
+    should "know its default backlog size" do
+      assert_equal 1024, DEFAULT_BACKLOG_SIZE
+    end
+
+    should "know its default shutdown timeout" do
+      assert_equal 15, DEFAULT_SHUTDOWN_TIMEOUT
+    end
+
     should "know its default number of workers" do
       assert_equal 2, DEFAULT_NUM_WORKERS
     end
@@ -134,7 +142,7 @@ class DatTCP::Server
 
     should "have it's TCPServer listening" do
       assert @tcp_server_spy.listening
-      assert_equal 1024, @tcp_server_spy.backlog_size
+      assert_equal DEFAULT_BACKLOG_SIZE, @tcp_server_spy.backlog_size
     end
 
     should "set the TCPServer's Socket::SO_REUSEADDR option to true" do


### PR DESCRIPTION
This updates the server spy to match the new server interface. This
is part of making sure the server spy is a good spy and useful. The
server spy now takes a worker class and makes sure it is a dat-tcp
worker. It also no longer takes any worker procs.

This also adds default constants for the server configuration. This
is so the server spy and use the same defaults.

@kellyredding - Ready for review.