### PR TITLE
Add worker test helpers

### DIFF
--- a/lib/dat-tcp/worker.rb
+++ b/lib/dat-tcp/worker.rb
@@ -11,6 +11,16 @@ module DatTCP
       end
     end
 
+    module TestHelpers
+
+      def self.included(klass)
+        klass.class_eval do
+          include DatWorkerPool::Worker::TestHelpers
+        end
+      end
+
+    end
+
   end
 
 end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -20,4 +20,17 @@ module DatTCP::Worker
 
   end
 
+  class TestHelpersTests < UnitTests
+    desc "TestHelpers"
+    setup do
+      @context_class = Class.new{ include TestHelpers }
+    end
+    subject{ @context_class }
+
+    should "mixin dat-worker-pool's worker test helpers" do
+      assert_includes DatWorkerPool::Worker::TestHelpers, @context_class
+    end
+
+  end
+
 end


### PR DESCRIPTION
This adds worker test helpers for testing custom dat-tcp workers.
This makes it possible for a custom dat-tcp worker to be easily
tested without requiring logic about the internals of dat-tcp.

The worker test helpers bring in dat-worker-pool's worker test
helpers.

@kellyredding - Ready for review.