### PR TITLE
get test suite passing in modern ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gemspec
 
 gem 'pry', "~> 0.9.0"
+
+gem 'dat-worker-pool', :path => "/Users/kelly/projects/redding/gems/dat-worker-pool"

--- a/dat-tcp.gemspec
+++ b/dat-tcp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
-  gem.add_development_dependency("scmd",   ["~> 3.0.1"])
+  gem.add_development_dependency("scmd",   ["~> 3.0.2"])
 
   gem.add_dependency("dat-worker-pool", ["~> 0.6.0"])
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -16,6 +16,8 @@ TEST_LOGGER = if ENV['DEBUG']
   Logger.new(ROOT_PATH.join("log/test.log")).tap{ |l| l.datetime_format = '' }
 end
 
+JOIN_SECONDS = 0.1
+
 require 'test/support/factory'
 
 # 1.8.7 backfills

--- a/test/system/echo_server_tests.rb
+++ b/test/system/echo_server_tests.rb
@@ -19,6 +19,7 @@ class EchoServerTests < Assert::Context
   should "have started a separate thread for running the server" do
     @server.listen('127.0.0.1', 56789)
     thread = @server.start
+    thread.join(JOIN_SECONDS)
 
     assert_instance_of Thread, thread
     assert_true thread.alive?

--- a/test/unit/dat-tcp_tests.rb
+++ b/test/unit/dat-tcp_tests.rb
@@ -188,6 +188,7 @@ class DatTCP::Server
     setup do
       @server.listen(@server_ip, @server_port)
       @thread = @server.start
+      @thread.join(JOIN_SECONDS)
     end
 
     should "return a thread for running the server" do
@@ -214,6 +215,7 @@ class DatTCP::Server
       @io_select_stub.set_client_on_tcp_server
       @server.listen(@server_ip, @server_port)
       @thread = @server.start
+      @thread.join(JOIN_SECONDS)
     end
 
     should "accept connections and add them to the worker pool" do
@@ -242,6 +244,7 @@ class DatTCP::Server
       end
       @server.listen(@server_ip, @server_port)
       @thread = @server.start(@clients.map(&:fileno))
+      @thread.join(JOIN_SECONDS)
     end
 
     should "add the clients to the worker pool" do
@@ -255,6 +258,7 @@ class DatTCP::Server
     setup do
       @server.listen(@server_ip, @server_port)
       @thread = @server.start
+      @thread.join(JOIN_SECONDS)
       @io_select_stub.set_data_on_signal_pipe
       @server.stop true
     end
@@ -284,6 +288,7 @@ class DatTCP::Server
     setup do
       @server.listen(@server_ip, @server_port)
       @thread = @server.start
+      @thread.join(JOIN_SECONDS)
       @io_select_stub.set_data_on_signal_pipe
       @server.halt true
     end
@@ -313,6 +318,7 @@ class DatTCP::Server
     setup do
       @server.listen(@server_ip, @server_port)
       @thread = @server.start
+      @thread.join(JOIN_SECONDS)
       @io_select_stub.set_data_on_signal_pipe
       @server.pause true
     end


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest patches
(which also now work in modern ruby versions) and updates the test
suite to get things passing in modern ruby versions. This mostly
involved doing more "hand-holding" to ensure threads were given a
chance to run or to reach a certain state before any assertions
were made.

I had to update the test support "echo server" to not stop the
server directly in the signal trap.  I switched to using the
"self pipe trick".  The test suite was throwing this error:
"dat-worker-pool/locked_object.rb:18:in `synchronize': can't be
called from trap context (ThreadError)". It looks like Ruby
pre-2.0 allowed a number of "unsafe" things (like this) while
2.0-plus is disallowing them.  See eventmachine, issue 418,
issuecomment-72972381 (I didn't link this directly b/c I didn't
want to add an activity item to that issue).

The test fixes themselves are just a couple tweaks:
- adding some extra thread joins to ensure they get a chance to run
- adding a test JOIN_SECONDS to standardize our thread joins

@jcredding ready for review.
